### PR TITLE
Allow clean, strong-typed fetching from any API through calling `Kwara()` function

### DIFF
--- a/lib/kwara.dart
+++ b/lib/kwara.dart
@@ -1,15 +1,20 @@
 import 'dart:convert';
-
 import 'package:http/http.dart' as http;
 
-/// Fetches data from a given [url] and returns it as a dynamic object.
-/// Throws an [Exception] if the request fails.
-Future<dynamic> Kwara(String url) async {
+//
+// --- HTTP Fetcher Function ---
+//
+
+Future<T> Kwara<T>(
+    String url, {
+      required T Function(Map<String, dynamic> json) fromJson,
+    }) async {
   try {
     final response = await http.get(Uri.parse(url));
 
     if (response.statusCode == 200) {
-      return jsonDecode(response.body);
+      final Map<String, dynamic> jsonMap = jsonDecode(response.body);
+      return fromJson(jsonMap);
     } else {
       throw Exception('Failed to load data: ${response.statusCode}');
     }
@@ -17,3 +22,61 @@ Future<dynamic> Kwara(String url) async {
     throw Exception('Error fetching data: $e');
   }
 }
+
+
+
+
+
+// import 'dart:convert';
+// import 'package:http/http.dart' as http;
+//
+// abstract class ApiModel {
+//   ApiModel fromJson(Map<String, dynamic> json);
+// }
+//
+// /// Generic function to fetch data from an API and parse it into an object of type [T].
+// Future<T> Kwara<T extends ApiModel>(
+//     String url, {
+//       required T Function(Map<String, dynamic> json) fromJson,
+//     }) async {
+//   try {
+//     final response = await http.get(Uri.parse(url));
+//
+//     if (response.statusCode == 200) {
+//       final Map<String, dynamic> jsonMap = jsonDecode(response.body);
+//       return fromJson(jsonMap);
+//     } else {
+//       throw Exception('Failed to load data: ${response.statusCode}');
+//     }
+//   } catch (e) {
+//     throw Exception('Error fetching data: $e');
+//   }
+// }
+
+
+
+
+
+
+
+
+
+// import 'dart:convert';
+//
+// import 'package:http/http.dart' as http;
+//
+// /// Fetches data from a given [url] and returns it as a dynamic object.
+// /// Throws an [Exception] if the request fails.
+// Future<dynamic> Kwara(String url) async {
+//   try {
+//     final response = await http.get(Uri.parse(url));
+//
+//     if (response.statusCode == 200) {
+//       return jsonDecode(response.body);
+//     } else {
+//       throw Exception('Failed to load data: ${response.statusCode}');
+//     }
+//   } catch (e) {
+//     throw Exception('Error fetching data: $e');
+//   }
+// }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,22 @@
-import 'package:not_kwara/kwara.dart';
+import 'kwara.dart';
+import 'morty.dart';
 
-void main() async{
+//
+// --- Example Usage ---
+//
+
+void main() async {
   const url = 'https://rickandmortyapi.com/api/character';
 
   try {
-    final data = await Kwara(url);
-    print(data);
+    // Pass 'fromJson' as a function (Wrap the static method)
+    final morty = await Kwara<Morty>(
+      url,
+      fromJson: (json) => Morty.fromJson(json), // Wrap it in a function
+    );
+
+    print('Total Characters: ${morty.info.count}');
+    print('First Character: ${morty.results.first.name}');
   } catch (e) {
     print('Error: $e');
   }

--- a/lib/morty.dart
+++ b/lib/morty.dart
@@ -1,0 +1,183 @@
+// To parse this JSON data, do
+//
+//     final morty = mortyFromJson(jsonString);
+
+import 'dart:convert';
+
+Morty mortyFromJson(String str) => Morty.fromJson(json.decode(str));
+
+String mortyToJson(Morty data) => json.encode(data.toJson());
+
+class Morty {
+  Info info;
+  List<Result> results;
+
+  Morty({
+    required this.info,
+    required this.results,
+  });
+
+  factory Morty.fromJson(Map<String, dynamic> json) => Morty(
+    info: Info.fromJson(json["info"]),
+    results: List<Result>.from(json["results"].map((x) => Result.fromJson(x))),
+  );
+
+  Map<String, dynamic> toJson() => {
+    "info": info.toJson(),
+    "results": List<dynamic>.from(results.map((x) => x.toJson())),
+  };
+}
+
+class Info {
+  int count;
+  int pages;
+  String next;
+  dynamic prev;
+
+  Info({
+    required this.count,
+    required this.pages,
+    required this.next,
+    required this.prev,
+  });
+
+  factory Info.fromJson(Map<String, dynamic> json) => Info(
+    count: json["count"],
+    pages: json["pages"],
+    next: json["next"],
+    prev: json["prev"],
+  );
+
+  Map<String, dynamic> toJson() => {
+    "count": count,
+    "pages": pages,
+    "next": next,
+    "prev": prev,
+  };
+}
+
+class Result {
+  int id;
+  String name;
+  Status status;
+  Species species;
+  String type;
+  Gender gender;
+  Location origin;
+  Location location;
+  String image;
+  List<String> episode;
+  String url;
+  DateTime created;
+
+  Result({
+    required this.id,
+    required this.name,
+    required this.status,
+    required this.species,
+    required this.type,
+    required this.gender,
+    required this.origin,
+    required this.location,
+    required this.image,
+    required this.episode,
+    required this.url,
+    required this.created,
+  });
+
+  factory Result.fromJson(Map<String, dynamic> json) => Result(
+    id: json["id"],
+    name: json["name"],
+    status: statusValues.map[json["status"]]!,
+    species: speciesValues.map[json["species"]]!,
+    type: json["type"],
+    gender: genderValues.map[json["gender"]]!,
+    origin: Location.fromJson(json["origin"]),
+    location: Location.fromJson(json["location"]),
+    image: json["image"],
+    episode: List<String>.from(json["episode"].map((x) => x)),
+    url: json["url"],
+    created: DateTime.parse(json["created"]),
+  );
+
+  Map<String, dynamic> toJson() => {
+    "id": id,
+    "name": name,
+    "status": statusValues.reverse[status],
+    "species": speciesValues.reverse[species],
+    "type": type,
+    "gender": genderValues.reverse[gender],
+    "origin": origin.toJson(),
+    "location": location.toJson(),
+    "image": image,
+    "episode": List<dynamic>.from(episode.map((x) => x)),
+    "url": url,
+    "created": created.toIso8601String(),
+  };
+}
+
+enum Gender {
+  FEMALE,
+  MALE,
+  UNKNOWN
+}
+
+final genderValues = EnumValues({
+  "Female": Gender.FEMALE,
+  "Male": Gender.MALE,
+  "unknown": Gender.UNKNOWN
+});
+
+class Location {
+  String name;
+  String url;
+
+  Location({
+    required this.name,
+    required this.url,
+  });
+
+  factory Location.fromJson(Map<String, dynamic> json) => Location(
+    name: json["name"],
+    url: json["url"],
+  );
+
+  Map<String, dynamic> toJson() => {
+    "name": name,
+    "url": url,
+  };
+}
+
+enum Species {
+  ALIEN,
+  HUMAN
+}
+
+final speciesValues = EnumValues({
+  "Alien": Species.ALIEN,
+  "Human": Species.HUMAN
+});
+
+enum Status {
+  ALIVE,
+  DEAD,
+  UNKNOWN
+}
+
+final statusValues = EnumValues({
+  "Alive": Status.ALIVE,
+  "Dead": Status.DEAD,
+  "unknown": Status.UNKNOWN
+});
+
+class EnumValues<T> {
+  Map<String, T> map;
+  late Map<T, String> reverseMap;
+
+  EnumValues(this.map);
+
+  Map<T, String> get reverse {
+    reverseMap = map.map((k, v) => MapEntry(v, k));
+    return reverseMap;
+  }
+}


### PR DESCRIPTION
- Forcing every call to call a model class.
- Handle enums properly with clean extension (no manual maps).
- Reduce duplication.
- Allowing for the calling of Kwara() to handle everything a user needs to call data and use it.